### PR TITLE
Update local notes with google doc links

### DIFF
--- a/components/TheoryModules.js
+++ b/components/TheoryModules.js
@@ -57,6 +57,23 @@ function TheoryModules({ courseCode }) {
     }
   };
 
+  // Helper utilities to resolve external links
+  const extractFileName = (path) => {
+    try {
+      const parts = String(path || '').split('/');
+      return decodeURIComponent(parts[parts.length - 1] || '');
+    } catch (e) {
+      return '';
+    }
+  };
+  const isExternalUrl = (url) => /^https?:\/\//.test(String(url || ''));
+  const resolveLink = (path) => {
+    const fileName = extractFileName(path);
+    const map = (window && window.EXTERNAL_NOTES && window.EXTERNAL_NOTES[courseCode]) || null;
+    const external = map && map[fileName];
+    return external || path;
+  };
+
   // Check if it's a lab course
   if (labCourses[courseCode]) {
     const lab = labCourses[courseCode];
@@ -250,8 +267,10 @@ function TheoryModules({ courseCode }) {
               {module.files.map((file) => (
                 <a
                   key={file.name}
-                  href={file.path}
-                  download
+                  href={resolveLink(file.path)}
+                  target={isExternalUrl(resolveLink(file.path)) ? '_blank' : undefined}
+                  rel={isExternalUrl(resolveLink(file.path)) ? 'noopener noreferrer' : undefined}
+                  download={!isExternalUrl(resolveLink(file.path))}
                   className="flex items-center gap-2 px-4 py-2 bg-white border-2 border-black rounded-lg shadow-[2px_2px_0px_0px_rgba(0,0,0,0.9)] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,0.9)] transition-all text-blue-700 font-semibold"
                 >
                   <span className="icon-download text-lg"></span>
@@ -346,8 +365,10 @@ function TheoryModules({ courseCode }) {
                   ) : (
                     <a
                       key={file.name}
-                      href={file.path}
-                      download
+                      href={resolveLink(file.path)}
+                      target={isExternalUrl(resolveLink(file.path)) ? '_blank' : undefined}
+                      rel={isExternalUrl(resolveLink(file.path)) ? 'noopener noreferrer' : undefined}
+                      download={!isExternalUrl(resolveLink(file.path))}
                       className="flex items-center gap-2 px-4 py-2 bg-white border-2 border-black rounded-lg shadow-[2px_2px_0px_0px_rgba(0,0,0,0.9)] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,0.9)] transition-all text-blue-700 font-semibold"
                     >
                       <span className="icon-download text-lg"></span>
@@ -421,8 +442,10 @@ function TheoryModules({ courseCode }) {
               {module.files.map((file) => (
                 <a
                   key={file.name}
-                  href={file.path}
-                  download
+                  href={resolveLink(file.path)}
+                  target={isExternalUrl(resolveLink(file.path)) ? '_blank' : undefined}
+                  rel={isExternalUrl(resolveLink(file.path)) ? 'noopener noreferrer' : undefined}
+                  download={!isExternalUrl(resolveLink(file.path))}
                   className="flex items-center gap-2 px-4 py-2 bg-white border-2 border-black rounded-lg shadow-[2px_2px_0px_0px_rgba(0,0,0,0.9)] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,0.9)] transition-all text-blue-700 font-semibold"
                 >
                   <span className="icon-download text-lg"></span>
@@ -492,8 +515,10 @@ function TheoryModules({ courseCode }) {
               {module.files.map((file) => (
                 <a
                   key={file.name}
-                  href={file.path}
-                  download
+                  href={resolveLink(file.path)}
+                  target={isExternalUrl(resolveLink(file.path)) ? '_blank' : undefined}
+                  rel={isExternalUrl(resolveLink(file.path)) ? 'noopener noreferrer' : undefined}
+                  download={!isExternalUrl(resolveLink(file.path))}
                   className="flex items-center gap-2 px-4 py-2 bg-white border-2 border-black rounded-lg shadow-[2px_2px_0px_0px_rgba(0,0,0,0.9)] hover:shadow-[4px_4px_0px_0px_rgba(0,0,0,0.9)] transition-all text-blue-700 font-semibold"
                 >
                   <span className="icon-download text-lg"></span>

--- a/index.html
+++ b/index.html
@@ -79,6 +79,8 @@
         <script type="text/babel" src="components/QuestionPapers.js"></script>
         <script type="text/babel"
             src="components/QuestionPapersYear.js"></script>
+        <!-- External notes mapping -->
+        <script type="text/babel" src="utils/notesLinks.js"></script>
         <script type="text/babel" src="utils/curriculumData.js"></script>
         <script type="text/babel" src="utils/courseContent.js"></script>
         <script type="text/babel" src="utils/questionPapersData.js"></script>

--- a/utils/courseContent.js
+++ b/utils/courseContent.js
@@ -255,12 +255,23 @@ function getModuleFilePath(courseCode, fileName) {
   };
   
   const semester = semesterMap[courseCode] || 'semester_i';
+  // Prefer external URL if configured
+  const external = (window && window.EXTERNAL_NOTES && window.EXTERNAL_NOTES[courseCode] && window.EXTERNAL_NOTES[courseCode][fileName]) || null;
+  if (external) return external;
   return `notes/${semester}/${courseCode}/${fileName}`;
 }
 
 // Function to download a module file
 function downloadModuleFile(courseCode, fileName, moduleTitle) {
   const filePath = getModuleFilePath(courseCode, fileName);
+  const isExternalUrl = (url) => /^https?:\/\//.test(String(url || ''));
+  
+  // If external URL, open in new tab
+  if (isExternalUrl(filePath)) {
+    window.open(filePath, '_blank');
+    showDownloadMessage(`🔗 Opening ${moduleTitle}...`);
+    return;
+  }
   
   // Check if file exists by making a HEAD request
   fetch(filePath, { method: 'HEAD' })

--- a/utils/notesLinks.js
+++ b/utils/notesLinks.js
@@ -1,9 +1,8 @@
 // Define external notes links mapping by course code and exact file name
 // Update the URLs to your Google Docs/Drive links. Keys must match the file names used in the UI.
 window.EXTERNAL_NOTES = window.EXTERNAL_NOTES || {
-  // Example:
-  // '20MCA102': {
-  //   'M1.2_ER_model.pdf': 'https://docs.google.com/file/d/FILE_ID/view',
-  //   'M1.3_er_diagram_to_table.pdf': 'https://drive.google.com/file/d/FILE_ID/view'
-  // }
+  '20MCA103': {
+    'Module 1.pdf': 'https://drive.google.com/uc?export=download&id=1S1LfaUv75YM4Shk__-WuCBZPXm6GYkLO',
+    'Module 5 Part 5.pdf': 'https://drive.google.com/uc?export=download&id=1WEpLm0n4NS5N-RcXy6GU6iu8GQfwmk9V'
+  }
 };

--- a/utils/notesLinks.js
+++ b/utils/notesLinks.js
@@ -1,0 +1,9 @@
+// Define external notes links mapping by course code and exact file name
+// Update the URLs to your Google Docs/Drive links. Keys must match the file names used in the UI.
+window.EXTERNAL_NOTES = window.EXTERNAL_NOTES || {
+  // Example:
+  // '20MCA102': {
+  //   'M1.2_ER_model.pdf': 'https://docs.google.com/file/d/FILE_ID/view',
+  //   'M1.3_er_diagram_to_table.pdf': 'https://drive.google.com/file/d/FILE_ID/view'
+  // }
+};


### PR DESCRIPTION
Add support for overriding local note files with external Google Docs/Drive URLs.

---
<a href="https://cursor.com/background-agent?bcId=bc-d486948a-6a50-4f9e-8333-659f1e55db35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d486948a-6a50-4f9e-8333-659f1e55db35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

